### PR TITLE
IMRV-60 Add configuration of osc client channel via config file

### DIFF
--- a/resources/Config/pd_fly.yaml
+++ b/resources/Config/pd_fly.yaml
@@ -13,3 +13,9 @@ app:
     - /F
 
   workingDir: C:\MRLab\Audio-Apps\Demo-Fly
+
+  oscClients:
+    - id: yami
+      subPath: osc
+      listenPort: 9336
+      destination: [ localhost, 10003 ]

--- a/resources/Config/pd_jungle.yaml
+++ b/resources/Config/pd_jungle.yaml
@@ -13,3 +13,9 @@ app:
     - /F
 
   workingDir: C:\MRLab\Audio-Apps\Demo-Jungle
+
+  oscClients:
+    - id: yami
+      subPath: osc
+      listenPort: 9340
+      destination: [ localhost, 10007 ]

--- a/resources/Config/reaper_music.yaml
+++ b/resources/Config/reaper_music.yaml
@@ -9,3 +9,9 @@ app:
   stopCommand: []
 
   workingDir: ""
+
+  oscClients:
+    - id: reaper
+      subPath: osc
+      listenPort: 9342
+      destination: [ localhost, 10009 ]

--- a/resources/Config/reaper_reverb.yaml
+++ b/resources/Config/reaper_reverb.yaml
@@ -9,3 +9,9 @@ app:
   stopCommand: []
 
   workingDir: ""
+
+  oscClients:
+    - id: reaper
+      subPath: osc
+      listenPort: 9338
+      destination: [ localhost, 10005 ]

--- a/resources/Config/reaper_test_mac.yaml
+++ b/resources/Config/reaper_test_mac.yaml
@@ -1,14 +1,26 @@
 name: Reaper Test Mac
 description: Reaper DAW generic test for development on Mac
+author: rumori
+date: 2026-01-31
+revision: 1
 
 app:
   startCommand:
     - /Applications/REAPER.app/Contents/MacOS/REAPER
-    - -new
+    - music.rpp
 
-  stopCommand: []
+  stopCommand:
+    - /Applications/REAPER.app/Contents/MacOS/REAPER
+    - -closeall:nosave:exit
 
-  workingDir: ""
+  workingDir: /Users/rm/Documents/1_projects/2025_mrlab/Audio-Apps/Demo-Music
+
+  oscClients:
+    - id: reaper
+      subPath: osc
+      prefix: ""
+      listenPort: 9342
+      destination: [ localhost, 10005 ]
 
   captureStdOut: false
   captureStdErr: false

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 target_sources (mrlabctrl_App
     PRIVATE
-        Config.h
+        Globals.h
         Main.cpp
 )
 
@@ -27,6 +27,7 @@ target_sources (mrlabctrl_Common
         controller/WebServerController.cpp
 
         util/ListenerInterface.h
+        util/Logger.h
 
         view/AppControlComponent.h
         view/AppControlComponent.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,12 +13,12 @@ target_sources (mrlabctrl_App
 
 target_sources (mrlabctrl_Common
     INTERFACE
-        controller/AppConfigController.h
-        controller/AppConfigController.cpp
         controller/AppController.h
         controller/AppController.cpp
         controller/AppHandle.h
         controller/AppHandle.cpp
+        controller/ConfigController.h
+        controller/ConfigController.cpp
         controller/MainController.h
         controller/MainController.cpp
         controller/OscController.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,8 @@ target_sources (mrlabctrl_Common
         controller/OscController.cpp
         controller/WebServerController.h
         controller/WebServerController.cpp
+        controller/YamlConfig.h
+        controller/YamlConfig.cpp
 
         util/ListenerInterface.h
         util/Logger.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@
 target_sources (mrlabctrl_App
     PRIVATE
         Globals.h
+        Globals.cpp
         Main.cpp
 )
 

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -1,0 +1,39 @@
+/*
+    Globals.cpp
+
+    Part of MR Lab Control Software
+
+    SPDX-License-Identifier: EUPL-1.2
+    SPDX-FileCopyrightText: Copyright (c) 2025 Martin Rumori/sonible GmbH
+ */
+
+#include "Globals.h"
+#include <JuceHeader.h>
+
+namespace mrlab
+{
+
+juce::File Globals::getAppSupportBaseDir()
+{
+#if JUCE_WINDOWS
+    return { juce::SystemStats::getEnvironmentVariable ("PROGRAMDATA", juce::File::getSpecialLocation (juce::File::commonApplicationDataDirectory).getFullPathName()) };
+#elif JUCE_MAC
+    return juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory).getChildFile ("Application Support");
+#elif JUCE_LINUX
+    return juce::File::getSpecialLocation (juce::File::userHomeDirectory).getChildFile (".local/share");
+#else
+    return juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory);
+#endif
+}
+
+juce::File Globals::getAppSupportDir()
+{
+    return getAppSupportBaseDir().getChildFile (ProjectInfo::projectName);
+}
+
+juce::File Globals::getLogFile()
+{
+    return getAppSupportDir().getChildFile ("MRLabLog.txt");
+}
+
+} // namespace mrlab

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_core/juce_core.h>
 
 namespace mrlab
 {
@@ -24,24 +24,13 @@ struct Globals
 {
     //==============================================================================
     /** @return The general application support base directory. */
-    static juce::File getAppSupportBaseDir()
-    {
-#if JUCE_WINDOWS
-        return { juce::SystemStats::getEnvironmentVariable ("PROGRAMDATA", juce::File::getSpecialLocation (juce::File::commonApplicationDataDirectory).getFullPathName()) };
-#elif JUCE_MAC
-        return juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory).getChildFile ("Application Support");
-#elif JUCE_LINUX
-        return juce::File::getSpecialLocation (juce::File::userHomeDirectory).getChildFile (".local/share");
-#else
-        return juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory);
-#endif
-    }
+    static juce::File getAppSupportBaseDir();
 
     /** @return The base directory of this application's data and associated resources. */
-    static juce::File getAppSupportDir()
-    {
-        return getAppSupportBaseDir().getChildFile (ProjectInfo::projectName);
-    }
+    static juce::File getAppSupportDir();
+
+    /** @return The location and name of the log file to be written. */
+    static juce::File getLogFile();
 
     /** @return The web server's document root (holds web gui data). */
     static juce::File getWebServerDocumentRootDir()
@@ -53,6 +42,12 @@ struct Globals
     static juce::File getConfigDir()
     {
         return getAppSupportDir().getChildFile ("Config");
+    }
+
+    /** @return The file extension of configuration files (app/routing/...). */
+    static juce::String getConfigFileExtension()
+    {
+      return "yaml";
     }
 
     //==============================================================================

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -1,5 +1,5 @@
 /*
-    Config.h
+    Globals.h
 
     Part of MR Lab Control Software
 
@@ -15,12 +15,12 @@ namespace mrlab
 {
 
 //==============================================================================
-/** Container for static configuration data.
+/** Container for static global configuration data.
 
     Collects hardcoded configuration data for now, might be extended
     by a configuration file reader.
  */
-struct Config
+struct Globals
 {
     //==============================================================================
     /** @return The general application support base directory. */
@@ -49,8 +49,8 @@ struct Config
         return getAppSupportDir().getChildFile ("WebGUI");
     }
 
-    /** @return The directory containing scene/app configurations. */
-    static juce::File getSceneConfigDir()
+    /** @return The directory containing configuration files (app/routing/...). */
+    static juce::File getConfigDir()
     {
         return getAppSupportDir().getChildFile ("Config");
     }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -29,6 +29,9 @@ public:
     {
         mainController = std::make_unique<controller::MainController>();
         mainWindow = std::make_unique<view::MainWindow> (getApplicationName(), *mainController);
+
+        // Load configuration files from app support directory.
+        mainController->getConfigController().populateFromConfigDir();
     }
 
     //==============================================================================

--- a/src/controller/AppController.cpp
+++ b/src/controller/AppController.cpp
@@ -33,7 +33,7 @@ bool AppController::add (const YamlConfig& config)
 
     try
     {
-        auto [iter, success] = apps.try_emplace (id, std::make_unique<AppHandle> (config));
+        auto [iter, success] = apps.try_emplace (id, std::make_unique<AppHandle> (mainController, config));
 
         if (success)
             listeners.call (&Listener::appAdded, *iter->second);

--- a/src/controller/AppController.cpp
+++ b/src/controller/AppController.cpp
@@ -8,81 +8,61 @@
  */
 
 #include "AppController.h"
+#include "MainController.h"
 #include "AppHandle.h"
-#include "ConfigController.h"
-#include <Globals.h>
+#include "YamlConfig.h"
 #include <util/Logger.h>
 
 namespace mrlab::controller
 {
 
-AppController::AppController (ConfigController& newConfigController)
-    : configController (newConfigController)
-{}
+AppController::AppController (MainController& mainControllerIn)
+    : mainController (mainControllerIn)
+{
+    mainController.getConfigController().addListener (this);
+}
 
 AppController::~AppController()
-{}
-
-void AppController::populateFromConfigDir()
 {
-    const auto configDir = Globals::getConfigDir();
+    mainController.getConfigController().removeListener (this);
+}
 
-    if (! configDir.isDirectory())
+bool AppController::add (const YamlConfig& config)
+{
+    const auto& id = config.getId();
+
+    try
     {
-        Logger::logWarn ("AppController: Config directory " + configDir.getFullPathName() + " does not exist.");
-        return;
+        auto [iter, success] = apps.try_emplace (id, std::make_unique<AppHandle> (config));
+
+        if (success)
+            listeners.call (&Listener::appAdded, *iter->second);
+        else
+            Logger::logWarn ("AppController: App has already been added for id: " + id.toString());
+
+        return success;
+    }
+    catch (const std::runtime_error& e)
+    {
+        Logger::logError ("AppController: Error adding app for id: " + id.toString() + "(" + e.what() + ").");
     }
 
-    Logger::logInfo ("AppController: Scanning config directory " + configDir.getFullPathName() + " for YAML configuration files.");
-    const auto yamlConfigs = configDir.findChildFiles (juce::File::TypesOfFileToFind::findFiles, true, "*.yaml");
-
-    for (const auto& config : yamlConfigs)
-        add (config);
-}
-
-bool AppController::add (const juce::Identifier& appId)
-{
-    auto appConfig = configController.findConfig (appId); // may throw
-
-    auto [iter, success] = apps.try_emplace (appId, std::make_unique<AppHandle> (std::move (appConfig)));
-
-    if (success)
-        listeners.call (&Listener::appAdded, *iter->second);
-
-    return success;
-}
-
-bool AppController::add (const juce::File& file)
-{
-    auto appConfig = configController.loadConfigFromFile (file);
-    if (! appConfig.has_value())
-        return false;
-
-    const auto id = appConfig->id;
-
-    auto [iter, success] = apps.try_emplace (id, std::make_unique<AppHandle> (std::move (*appConfig)));
-
-    if (success)
-        listeners.call (&Listener::appAdded, *iter->second);
-
-    return success;
+    return false;
 }
 
 bool AppController::remove (const juce::Identifier& appId)
 {
     checkForAppAndThrowIfNotFound (appId);
 
-    auto& app = apps.at (appId);
-
-    if (app->isRunning())
+    if (apps.at (appId)->isRunning())
     {
-        jassertfalse; // App should be checked for a non-running state before attempting to remove it.
+        Logger::logWarn ("AppController: Ignoring removal attempt of still running app with id: " + appId.toString());
+        jassertfalse;
+
         return false;
     }
 
-    listeners.call (&Listener::appWillBeRemoved, *app);
-
-    apps.erase (appId);
+    removeForced (appId);
 
     return true;
 }
@@ -122,6 +102,52 @@ const AppHandle& AppController::getApp (const juce::Identifier& appId) const
     checkForAppAndThrowIfNotFound (appId);
 
     return *apps.at (appId);
+}
+
+void AppController::configAdded (const YamlConfig& config)
+{
+    // Ignore configurations that do not affect us.
+    if (! config.hasSection (YamlConfig::Section::app))
+        return;
+
+    if (! add (config))
+        Logger::logWarn ("AppController: Error adding app for newly appeared config with id: " + config.getId().toString());
+}
+
+void AppController::configWillBeRemoved (const YamlConfig& config)
+{
+    const auto id = config.getId();
+
+    // Ignore configurations that do not affect us.
+    if (! config.hasSection (YamlConfig::Section::app))
+    {
+        // Somehow we ended up managing an app without an app config section?
+        jassert (! hasApp (id));
+        return;
+    }
+
+    if (! hasApp (id))
+        return;
+
+    /* Try to be gentle and issue the app's stop command in case it is
+       running, but we are actually going to kill it right after.
+     */
+    auto& app = getApp (id);
+
+    if (app.isRunning())
+    {
+        Logger::logWarn ("AppController: Config for running app with id '" + id.toString() + "' is going to be removed. Stopping/killing app.");
+
+        app.stop();
+    }
+
+    removeForced (id);
+}
+
+void AppController::removeForced (const juce::Identifier& appId)
+{
+    listeners.call (&Listener::appWillBeRemoved, *apps.at (appId));
+    apps.erase (appId);
 }
 
 void AppController::checkForAppAndThrowIfNotFound (const juce::Identifier& appId) const

--- a/src/controller/AppController.cpp
+++ b/src/controller/AppController.cpp
@@ -10,7 +10,7 @@
 #include "AppController.h"
 #include "AppHandle.h"
 #include "AppConfigController.h"
-#include <Config.h>
+#include <Globals.h>
 #include <util/Logger.h>
 
 namespace mrlab::controller
@@ -23,18 +23,18 @@ AppController::AppController (AppConfigController& configController)
 AppController::~AppController()
 {}
 
-void AppController::populateFromSceneConfigDir()
+void AppController::populateFromConfigDir()
 {
-    const auto sceneConfigDir = Config::getSceneConfigDir();
+    const auto configDir = Globals::getConfigDir();
 
-    if (! sceneConfigDir.isDirectory())
+    if (! configDir.isDirectory())
     {
-        Logger::logWarn ("AppController: Scene config directory " + sceneConfigDir.getFullPathName() + " does not exist.");
+        Logger::logWarn ("AppController: Config directory " + configDir.getFullPathName() + " does not exist.");
         return;
     }
 
-    Logger::logInfo ("AppController: Scanning scene config directory " + sceneConfigDir.getFullPathName() + " for YAML configuration files.");
-    const auto yamlConfigs = sceneConfigDir.findChildFiles (juce::File::TypesOfFileToFind::findFiles, true, "*.yaml");
+    Logger::logInfo ("AppController: Scanning config directory " + configDir.getFullPathName() + " for YAML configuration files.");
+    const auto yamlConfigs = configDir.findChildFiles (juce::File::TypesOfFileToFind::findFiles, true, "*.yaml");
 
     for (const auto& config : yamlConfigs)
         add (config);

--- a/src/controller/AppController.cpp
+++ b/src/controller/AppController.cpp
@@ -9,15 +9,15 @@
 
 #include "AppController.h"
 #include "AppHandle.h"
-#include "AppConfigController.h"
+#include "ConfigController.h"
 #include <Globals.h>
 #include <util/Logger.h>
 
 namespace mrlab::controller
 {
 
-AppController::AppController (AppConfigController& configController)
-    : appConfigController (configController)
+AppController::AppController (ConfigController& newConfigController)
+    : configController (newConfigController)
 {}
 
 AppController::~AppController()
@@ -42,7 +42,7 @@ void AppController::populateFromConfigDir()
 
 bool AppController::add (const juce::Identifier& appId)
 {
-    auto appConfig = appConfigController.findConfig (appId); // may throw
+    auto appConfig = configController.findConfig (appId); // may throw
 
     auto [iter, success] = apps.try_emplace (appId, std::make_unique<AppHandle> (std::move (appConfig)));
 
@@ -54,7 +54,7 @@ bool AppController::add (const juce::Identifier& appId)
 
 bool AppController::add (const juce::File& file)
 {
-    auto appConfig = appConfigController.loadConfigFromFile (file);
+    auto appConfig = configController.loadConfigFromFile (file);
     if (! appConfig.has_value())
         return false;
 

--- a/src/controller/AppController.h
+++ b/src/controller/AppController.h
@@ -68,7 +68,7 @@ public:
     ~AppController();
 
     /** Read all configurations from the scene config dir. */
-    void populateFromSceneConfigDir();
+    void populateFromConfigDir();
 
     /** Add an app handle for appId to this controller.
 

--- a/src/controller/AppController.h
+++ b/src/controller/AppController.h
@@ -18,7 +18,7 @@ namespace mrlab::controller
 {
 
 class AppHandle;
-class AppConfigController;
+class ConfigController;
 
 //==============================================================================
 class AppController
@@ -63,7 +63,7 @@ public:
     };
 
     //==============================================================================
-    AppController (AppConfigController& configController);
+    AppController (ConfigController& configController);
 
     ~AppController();
 
@@ -77,7 +77,7 @@ public:
 
         @param appId Unique app identifier.
         @returns true on success, false if there is already an app with this id.
-        @throws AppConfigNotFoundException.
+        @throws ConfigNotFoundException.
      */
     bool add (const juce::Identifier& appId);
 
@@ -161,7 +161,7 @@ private:
     };
 
     //==============================================================================
-    AppConfigController& appConfigController;
+    ConfigController& configController;
 
     std::map<juce::Identifier, std::unique_ptr<AppHandle>> apps; ///< Managed apps.
     std::unique_ptr<AppStopTimer> appStopTimer;                  ///< Helper used in stopAllApps().

--- a/src/controller/AppController.h
+++ b/src/controller/AppController.h
@@ -13,30 +13,25 @@
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
 #include <util/ListenerInterface.h>
+#include "ConfigController.h"
 
 namespace mrlab::controller
 {
-
+class MainController;
 class AppHandle;
-class ConfigController;
 
 //==============================================================================
-class AppController
+class AppController : public ConfigController::Listener
 {
 public:
     //==============================================================================
     /** Exception that is thrown when there is no app for the given id. */
-    class AppUnknownException : public std::exception
+    class AppUnknownException : public std::runtime_error
     {
     public:
-        AppUnknownException (const juce::Identifier& appId)
-            : msg ("AppUnknownException: no app found with id " + appId.toString())
+        AppUnknownException (const juce::Identifier& id)
+            : std::runtime_error ("AppUnknownException: No app found with id " + id.toString().toStdString())
         {}
-
-        const char* what() const noexcept override { return msg.toUTF8(); }
-
-    protected:
-        juce::String msg;
     };
 
     //==============================================================================
@@ -63,32 +58,24 @@ public:
     };
 
     //==============================================================================
-    AppController (ConfigController& configController);
+    AppController (MainController& mainControllerIn);
 
-    ~AppController();
+    ~AppController() override;
 
-    /** Read all configurations from the scene config dir. */
-    void populateFromConfigDir();
+    /** Add an app handle for a given config to this controller.
 
-    /** Add an app handle for appId to this controller.
+        The provided config needs to contain an app configuration
+        section for this to work.
 
-        This will acquire a matching app configuration for instantiating a handle.
-        If there is already a handle for appId, it should be removed before calling this.
+        @param config configuration to use.
 
-        @param appId Unique app identifier.
-        @returns true on success, false if there is already an app with this id.
-        @throws ConfigNotFoundException.
+        @returns true on success, false if there is already an app
+                 with this id or if the provided configuration does
+                 not contain an app section.
      */
-    bool add (const juce::Identifier& appId);
+    bool add (const YamlConfig& config);
 
-    /** Add an app handle for appId to this controller by file.
-
-        @param file the file on disk.
-        @returns true on success, false if there is already an app with this id.
-     */
-    bool add (const juce::File& file);
-
-    /** Remove the app handle for appId from this controller.
+    /** Remove the app handle for id from this controller.
 
         This is only supported for apps that are not running.
 
@@ -123,6 +110,9 @@ public:
      */
     bool isAnyAppRunning() const;
 
+    /** Check whether this manages an app with the given id. */
+    bool hasApp (const juce::Identifier& appId) const { return apps.contains (appId); }
+
     /** Get the app handle for appId.
 
         @returns The matching handle for appId.
@@ -142,6 +132,13 @@ public:
 
 private:
     //==============================================================================
+    // ConfigController::Listener interface.
+    void configAdded (const YamlConfig& config) override;
+    void configWillBeRemoved (const YamlConfig& config) override;
+
+    /** Remove an app handle independent of its running state, possibly killing it. */
+    void removeForced (const juce::Identifier& appId);
+
     /** Check whether we know about an appId and throw an exception otherwise. */
     void checkForAppAndThrowIfNotFound (const juce::Identifier& appId) const;
 
@@ -161,7 +158,7 @@ private:
     };
 
     //==============================================================================
-    ConfigController& configController;
+    MainController& mainController;
 
     std::map<juce::Identifier, std::unique_ptr<AppHandle>> apps; ///< Managed apps.
     std::unique_ptr<AppStopTimer> appStopTimer;                  ///< Helper used in stopAllApps().

--- a/src/controller/AppHandle.cpp
+++ b/src/controller/AppHandle.cpp
@@ -9,13 +9,15 @@
 
 #include "AppHandle.h"
 #include "YamlConfig.h"
+#include "MainController.h"
 #include <util/Logger.h>
 
 namespace mrlab::controller
 {
 
-AppHandle::AppHandle (const YamlConfig& newConfig)
-    : config (newConfig)
+AppHandle::AppHandle (MainController& mainControllerIn, const YamlConfig& newConfig)
+    : mainController (mainControllerIn),
+      config (newConfig)
 {
     if (! config.hasSection (YamlConfig::Section::app))
         throw YamlConfig::UnusableConfigException ("Missing config section 'app'.");
@@ -66,6 +68,30 @@ AppHandle::AppState AppHandle::start()
     if (! success)
         return state;
 
+    // Add subpath OSC server if config calls or it.
+    if (const auto oscClients = appConfig["oscClients"]; oscClients)
+    {
+        // We only support one client entry for now.
+        if (oscClients.size() > 1)
+            Logger::logWarn ("AppHandle: Ignoring additional oscClient entries in app config with id " + config.getId().toString());
+
+        const auto osc = oscClients[0];
+
+        if (! osc["prefix"].as<std::string>().empty())
+            Logger::logWarn ("AppHandle: Ignoring oscClient 'prefix' entry (not yet implemented) in app config with id " + config.getId().toString());
+
+        if (! mainController.getOscController().addSubPathServer (config.getId(),
+                                                                  "/app/" + config.getId().toString().toStdString() + "/" + osc["subPath"].as<std::string>(),
+                                                                  osc["listenPort"].as<uint16_t>(),
+                                                                  osc["destination"][0].as<std::string>(),
+                                                                  osc["destination"][1].as<uint16_t>()))
+        {
+            Logger::logError ("AppHandle: Establishing osc client channel failed for app with id " + config.getId().toString());
+
+            setStateAndNotify (AppState::lost);
+        }
+    }
+
     startTimer (TimerId::stateUpdate, stateUpdateMs);
 
     // Start reading the output asynchronously as juce::ChildProcess::readProcessOutput() is blocking.
@@ -91,7 +117,8 @@ AppHandle::AppState AppHandle::start()
 
     // TODO: implement waiting for app to become ready (IMRV-33).
     // For now, we just become ready after a delay.
-    startTimer (TimerId::appReadyTimeout, appReadyTimeoutMs);
+    if (state == AppState::alive)
+        startTimer (TimerId::appReadyTimeout, appReadyTimeoutMs);
 
     return state;
 }
@@ -100,6 +127,9 @@ AppHandle::AppState AppHandle::stop()
 {
     if (! isRunning())
         return state;
+
+    // Remove potentially added subpath OSC server.
+    mainController.getOscController().removeServer (config.getId());
 
     juce::StringArray stopCommand;
 
@@ -139,7 +169,12 @@ AppHandle::AppState AppHandle::stop()
 AppHandle::AppState AppHandle::kill()
 {
     if (process.isRunning())
+    {
+        // Remove potentially added subpath OSC server.
+        mainController.getOscController().removeServer (config.getId());
+
         setStateAndNotify (process.kill() ? AppState::killRequested : AppState::killRequestFailed);
+    }
 
     return state;
 }
@@ -178,7 +213,7 @@ void AppHandle::timerCallback (int timerId)
             break;
 
         default:
-            ;
+            jassertfalse; // Unhandled timer id.
     }
 }
 
@@ -210,6 +245,9 @@ void AppHandle::updateState()
 
     captureThread.reset();
     // TODO: Implement crash detection of app (IMRV-35).
+
+    // Remove potentially added subpath OSC server.
+    mainController.getOscController().removeServer (config.getId());
 }
 
 void AppHandle::updateOutput()

--- a/src/controller/AppHandle.cpp
+++ b/src/controller/AppHandle.cpp
@@ -8,35 +8,55 @@
  */
 
 #include "AppHandle.h"
+#include "YamlConfig.h"
+#include <util/Logger.h>
 
 namespace mrlab::controller
 {
 
-AppHandle::AppHandle (AppConfig newConfig)
-    : config (std::move (newConfig))
-{}
+AppHandle::AppHandle (const YamlConfig& newConfig)
+    : config (newConfig)
+{
+    if (! config.hasSection (YamlConfig::Section::app))
+        throw YamlConfig::UnusableConfigException ("Missing config section 'app'.");
+}
+
+AppHandle::~AppHandle()
+{
+    kill();
+    captureThread.reset(); // Might block until app process is gone.
+}
 
 AppHandle::AppState AppHandle::start()
 {
     if (isRunning() || process.isRunning())
         return state;
 
-    int streamFlags = (config.captureStdOut ? juce::ChildProcess::wantStdOut : 0) |
-                      (config.captureStdErr ? juce::ChildProcess::wantStdErr : 0);
+    const auto appConfig = config.getSection (YamlConfig::Section::app);
 
-    // Save current working directory later restore after app launch.
+    int streamFlags = (appConfig["captureStdOut"].as<bool>() ? juce::ChildProcess::wantStdOut : 0) |
+                      (appConfig["captureStdErr"].as<bool>() ? juce::ChildProcess::wantStdErr : 0);
+
+    // Save current working directory in order to restore it after app launch.
     const auto currentWorkingDir = juce::File::getCurrentWorkingDirectory();
 
-    // Change to configured app working directory if specified (non-empty).
-    if (config.workingDir != juce::String() && ! config.workingDir.setAsCurrentWorkingDirectory())
+    // Change to configured app working directory (fallback: app support dir).
+    const auto workingDir = Globals::getAppSupportDir().getChildFile (appConfig["workingDir"].as<std::string>());
+
+    if (! workingDir.setAsCurrentWorkingDirectory())
     {
-        std::cerr << "AppHandle::start(): Could not set working directory " << config.workingDir.getFullPathName() << std::endl;
+        Logger::logError ("AppHandle: Could not set working directory " + workingDir.getFullPathName() + " for app with id: " + config.getId().toString());
         setStateAndNotify (AppState::startFailed);
         return state;
     }
 
     // Try to launch app.
-    const auto success = process.start (config.startCommand, streamFlags);
+    juce::StringArray startCommand;
+
+    for (const auto& child : appConfig["startCommand"])
+        startCommand.add (child.as<std::string>());
+
+    const auto success = process.start (startCommand, streamFlags);
 
     // Restore previously saved working directory.
     currentWorkingDir.setAsCurrentWorkingDirectory();
@@ -46,7 +66,7 @@ AppHandle::AppState AppHandle::start()
     if (! success)
         return state;
 
-    startTimerHz (stateUpdateHz);
+    startTimer (TimerId::stateUpdate, stateUpdateMs);
 
     // Start reading the output asynchronously as juce::ChildProcess::readProcessOutput() is blocking.
     if (streamFlags)
@@ -69,14 +89,9 @@ AppHandle::AppState AppHandle::start()
         captureThread = std::make_unique<std::jthread> (std::move (readOutput));
     }
 
-    // TODO: implement waiting for app to become ready (IMRV-33)
-    // for now, we just become ready 3 seconds after launching.
-    juce::Timer::callAfterDelay (3000, [&] {
-        if (state != AppState::alive)
-            return;
-
-        setStateAndNotify (AppState::ready);
-    });
+    // TODO: implement waiting for app to become ready (IMRV-33).
+    // For now, we just become ready after a delay.
+    startTimer (TimerId::appReadyTimeout, appReadyTimeoutMs);
 
     return state;
 }
@@ -86,24 +101,30 @@ AppHandle::AppState AppHandle::stop()
     if (! isRunning())
         return state;
 
-    if (config.stopCommand.isEmpty())
+    juce::StringArray stopCommand;
+
+    for (const auto& child : config.getSection (YamlConfig::Section::app)["stopCommand"])
+        stopCommand.add (child.as<std::string>());
+
+    if (stopCommand.isEmpty())
         return kill();
 
     juce::ChildProcess stopProcess;
 
-    if (! (stopProcess.start (config.stopCommand) &&
+    if (! (stopProcess.start (stopCommand) &&
            stopProcess.waitForProcessToFinish (1000) &&
            stopProcess.getExitCode() == 0))
     {
         if (stopProcess.isRunning())
         {
-            std::cerr << "AppHandle::stop(): stopCommand is taking too long, killing it..." << std::endl;
+            Logger::logWarn ("AppHandle: stopCommand for app with id " + config.getId().toString() + " is taking too long, killing it.");
             stopProcess.kill();
         }
         else
         {
-            std::cerr << "AppHandle::stop(): stopCommand returned " << stopProcess.getExitCode() << ": "
-                      << stopProcess.readAllProcessOutput() << std::endl;
+            Logger::logWarn ("AppHandle: stopCommand for app with id " + config.getId().toString() +
+                             " returned with exit code " + juce::String (stopProcess.getExitCode()) +
+                             " (" + stopProcess.readAllProcessOutput() + ").");
         }
 
         setStateAndNotify (AppState::stopRequestFailed);
@@ -123,6 +144,11 @@ AppHandle::AppState AppHandle::kill()
     return state;
 }
 
+const juce::Identifier& AppHandle::getId() const
+{
+    return config.getId();
+}
+
 uint32_t AppHandle::getExitCode() const
 {
     jassert (isFinished());
@@ -130,14 +156,30 @@ uint32_t AppHandle::getExitCode() const
     return process.getExitCode();
 }
 
-void AppHandle::timerCallback()
+void AppHandle::timerCallback (int timerId)
 {
-    updateState();
+    switch (timerId)
+    {
+        case TimerId::stateUpdate:
+            updateState();
 
-    if (! isRunning())
-        stopTimer();
+            if (! isRunning())
+                stopTimer (TimerId::stateUpdate);
 
-    updateOutput();
+            updateOutput();
+            break;
+
+        case TimerId::appReadyTimeout:
+            stopTimer (TimerId::appReadyTimeout); // Single-shot timer.
+
+            if (state == AppState::alive)
+                setStateAndNotify (AppState::ready);
+
+            break;
+
+        default:
+            ;
+    }
 }
 
 void AppHandle::setStateAndNotify (AppState newState)

--- a/src/controller/AppHandle.h
+++ b/src/controller/AppHandle.h
@@ -13,7 +13,7 @@
 #include <juce_events/juce_events.h>
 #include <util/ListenerInterface.h>
 #include <thread>
-#include "AppConfigController.h"
+#include "ConfigController.h"
 
 namespace mrlab::controller
 {

--- a/src/controller/AppHandle.h
+++ b/src/controller/AppHandle.h
@@ -13,13 +13,13 @@
 #include <juce_events/juce_events.h>
 #include <util/ListenerInterface.h>
 #include <thread>
-#include "ConfigController.h"
 
 namespace mrlab::controller
 {
+class YamlConfig;
 
 //==============================================================================
-class AppHandle : private juce::Timer
+class AppHandle : private juce::MultiTimer
 {
 public:
     //==============================================================================
@@ -103,9 +103,12 @@ public:
     //==============================================================================
     /** Create an AppHandle according to an app config.
 
-        @param config App config to use.
+        @param config Configuration containing an app section.
+        @throws UnusableConfigException in case the app section is missing.
      */
-    AppHandle (AppConfig newConfig);
+    AppHandle (const YamlConfig& newConfig);
+
+    ~AppHandle() override;
 
     /** Attempt to start this app according to the configuration.
 
@@ -137,16 +140,21 @@ public:
         If the app process is not running, this will do nothing but
         returning its current state.
 
-        @returns AppState::killed on success, AppState::killFailed on failure,
-                 or the previous AppState if process was not running.
+        @note It still depends on the system whether and how quickly
+              the app process gets actually killed after this has
+              returned.
+
+        @returns AppState::killRequested on success,
+                 AppState::killRequestFailed on failure, or the
+                 previous AppState if process was not running.
      */
     AppState kill();
 
-    /** Get the configuration of this app.
+    /** Get the configuration id of this app.
 
-        @returns The app configuration.
+        @returns The id of the app configuration.
     */
-    const AppConfig& getConfig() const { return config; }
+    const juce::Identifier& getId() const;
 
     /** Get the current state of this app.
 
@@ -186,11 +194,21 @@ public:
 
 private:
     //==============================================================================
-    /** Rate at which to update the process state and to read the process output. */
-    static constexpr auto stateUpdateHz = 10;
+    /** Ids for the timers used in this class. */
+    enum TimerId
+    {
+        stateUpdate = 0,        ///< Period timer checking for process state updates.
+        appReadyTimeout = 1     ///< Delay for timeout-based setting an app ready.
+    };
+
+    /** Interval at which to update the process state and to read the process output. */
+    static constexpr auto stateUpdateMs = 100;
+
+    /** Default timeout for setting a started up to 'ready' state. */
+    static constexpr auto appReadyTimeoutMs = 3000;
 
     //==============================================================================
-    void timerCallback() override;
+    void timerCallback (int timerId) override;
 
     /** Sets the app state and notifies listeners. */
     void setStateAndNotify (AppState newState);
@@ -202,7 +220,7 @@ private:
     void updateOutput();
 
     //==============================================================================
-    AppConfig config;                            ///< App configuration.
+    const YamlConfig& config;                    ///< Reference to the app configuration.
     juce::ChildProcess process;                  ///< Actual app process.
     AppState state = AppState::init;             ///< Current app state.
     juce::String lastOutput;                     ///< Last available output captured from the app.

--- a/src/controller/AppHandle.h
+++ b/src/controller/AppHandle.h
@@ -16,6 +16,7 @@
 
 namespace mrlab::controller
 {
+class MainController;
 class YamlConfig;
 
 //==============================================================================
@@ -50,7 +51,7 @@ public:
         alive           = running,      ///< App process is alive but app logic not yet considered ready.
         ready,                          ///< App is ready to be used/controlled.
         busy,                           ///< App indicates that it is not ready to be controlled.
-        lost,                           ///< Connection to the app was lost.
+        lost,                           ///< Connection to the app was lost (e.g., osc client channel could not be established).
 
         stopRequested,                  ///< App has been requested to stop gracefully.
         stopRequestFailed,              ///< Failure while requesting to stop gracefully.
@@ -106,7 +107,7 @@ public:
         @param config Configuration containing an app section.
         @throws UnusableConfigException in case the app section is missing.
      */
-    AppHandle (const YamlConfig& newConfig);
+    AppHandle (MainController& mainControllerIn, const YamlConfig& newConfig);
 
     ~AppHandle() override;
 
@@ -220,6 +221,7 @@ private:
     void updateOutput();
 
     //==============================================================================
+    MainController& mainController;              ///< Reference to the main controller.
     const YamlConfig& config;                    ///< Reference to the app configuration.
     juce::ChildProcess process;                  ///< Actual app process.
     AppState state = AppState::init;             ///< Current app state.

--- a/src/controller/ConfigController.cpp
+++ b/src/controller/ConfigController.cpp
@@ -1,5 +1,5 @@
 /*
-    AppConfigController.cpp
+    ConfigController.cpp
 
     Part of MR Lab Control Software
 
@@ -7,16 +7,16 @@
     SPDX-FileCopyrightText: Copyright (c) 2025 Martin Rumori/sonible GmbH
  */
 
-#include "AppConfigController.h"
+#include "ConfigController.h"
 #include <util/Logger.h>
 
 namespace mrlab::controller
 {
 
-AppConfigController::AppConfigController()
+ConfigController::ConfigController()
 {}
 
-AppConfig AppConfigController::findConfig (const juce::Identifier& appId) const
+AppConfig ConfigController::findConfig (const juce::Identifier& appId) const
 {
     if (appId == configFly)
     {
@@ -87,10 +87,10 @@ AppConfig AppConfigController::findConfig (const juce::Identifier& appId) const
         };
     }
 
-    throw AppConfigNotFoundException (appId);
+    throw ConfigNotFoundException (appId);
 }
 
-std::optional<AppConfig> AppConfigController::loadConfigFromFile (const juce::File& yamlFile)
+std::optional<AppConfig> ConfigController::loadConfigFromFile (const juce::File& yamlFile)
 {
     Logger::logInfo (juce::String ("Loading config file ") + yamlFile.getFullPathName());
 
@@ -146,11 +146,11 @@ std::optional<AppConfig> AppConfigController::loadConfigFromFile (const juce::Fi
     return cfg;
 }
 
-bool AppConfigController::parseYamlFile (const juce::File& yamlFile, YamlDocument& document)
+bool ConfigController::parseYamlFile (const juce::File& yamlFile, YamlDocument& document)
 {
     if (! yamlFile.existsAsFile())
     {
-        Logger::logError (juce::String ("AppConfigController::parseYamlFile(): Config file not found."));
+        Logger::logError (juce::String ("ConfigController::parseYamlFile(): Config file not found."));
         return false;
     }
 
@@ -160,14 +160,14 @@ bool AppConfigController::parseYamlFile (const juce::File& yamlFile, YamlDocumen
     }
     catch (const std::exception& e)
     {
-        Logger::logError (juce::String ("AppConfigController::parseYamlFile(): Failed to parse YAML file with error: ") + e.what());
+        Logger::logError (juce::String ("ConfigController::parseYamlFile(): Failed to parse YAML file with error: ") + e.what());
         return false;
     }
 
     return true;
 }
 
-bool AppConfigController::validateYamlDocument (const YamlDocument& document)
+bool ConfigController::validateYamlDocument (const YamlDocument& document)
 {
     // check top level contents
     const auto root = document.node;

--- a/src/controller/ConfigController.cpp
+++ b/src/controller/ConfigController.cpp
@@ -8,206 +8,104 @@
  */
 
 #include "ConfigController.h"
+#include "YamlConfig.h"
+#include <Globals.h>
 #include <util/Logger.h>
 
 namespace mrlab::controller
 {
 
-ConfigController::ConfigController()
-{}
+ConfigController::ConfigController() {}
 
-AppConfig ConfigController::findConfig (const juce::Identifier& appId) const
+ConfigController::~ConfigController() {}
+
+const YamlConfig& ConfigController::getConfig (const juce::Identifier& id) const
 {
-    if (appId == configFly)
-    {
-        return {
-            .id = configFly,
-            .name = "Pd Fly",
-            .description = "Pd with Fly demonstration",
-#if JUCE_WINDOWS
-            .startCommand = juce::StringArray ("C:\\PD\\YAMI\\FLY.bat"),
-            .stopCommand = juce::StringArray ("C:\\Windows\\System32\\taskkill", "/IM", "pd.com", "/T", "/F"),
-            .workingDir = juce::File ("C:\\PD\\YAMI")
-#elif JUCE_MAC
-            .startCommand = juce::StringArray ("/Applications/Pd-0.56-2.app/Contents/MacOS/Pd",
-                                               "/Users/rm/Documents/Pd/test_stdout.pd"),
-            .stopCommand = juce::StringArray ("killall", "Pd"),
-            .workingDir = juce::File ("/Users/rm/Documents/Pd")
-#endif
-        };
-    }
+    checkForConfigAndThrowIfNotFound (id);
 
-    if (appId == configReverb)
-    {
-        return {
-            .id = configReverb,
-            .name = "Reaper Reverb",
-            .description = "Reaper DAW with artificial reverb",
-#if JUCE_WINDOWS
-            .startCommand = juce::StringArray ("C:\\Program Files\\REAPER (x64)\\reaper",
-                                               "reverb.rpp")
-#elif JUCE_MAC
-            .startCommand = juce::StringArray ("/Applications/REAPER.app/Contents/MacOS/REAPER",
-                                               "-new")
-#endif
-        };
-    }
-
-    if (appId == configJungle)
-    {
-        return {
-            .id = configJungle,
-            .name = "Pd Jungle",
-            .description = "Pd with Jungle demonstration",
-#if JUCE_WINDOWS
-            .startCommand = juce::StringArray ("C:\\PD\\YAMI\\JUNGLE.bat"),
-            .stopCommand = juce::StringArray ("C:\\Windows\\System32\\taskkill", "/IM", "pd.com", "/T", "/F"),
-            .workingDir = juce::File ("C:\\PD\\YAMI")
-#elif JUCE_MAC
-            .startCommand = juce::StringArray ("/Applications/Pd-0.56-2.app/Contents/MacOS/Pd",
-                                               "/Users/rm/Documents/Pd/test_stdout.pd"),
-            .stopCommand = juce::StringArray ("killall", "Pd")
-#endif
-        };
-    }
-
-    if (appId == configMusic)
-    {
-        return {
-            .id = configMusic,
-            .name = "Reaper Music",
-            .description = "Reaper DAW with music example",
-#if JUCE_WINDOWS
-            .startCommand = juce::StringArray ("C:\\Program Files\\REAPER (x64)\\reaper",
-                                               "music.rpp")
-#elif JUCE_MAC
-            .startCommand = juce::StringArray ("/Applications/REAPER.app/Contents/MacOS/REAPER",
-                                               "-new")
-#endif
-        };
-    }
-
-    throw ConfigNotFoundException (appId);
+    return *configs.at (id);
 }
 
-std::optional<AppConfig> ConfigController::loadConfigFromFile (const juce::File& yamlFile)
+bool ConfigController::loadConfig (const juce::File& yamlFile)
 {
-    Logger::logInfo (juce::String ("Loading config file ") + yamlFile.getFullPathName());
+    return loadConfig (yamlFile.getFileNameWithoutExtension(), yamlFile);
+}
 
-    YamlDocument doc;
+bool ConfigController::loadConfig (const juce::Identifier& id)
+{
+    const auto file = Globals::getConfigDir().getChildFile (id.toString()).withFileExtension (Globals::getConfigFileExtension());
 
-    if (! parseYamlFile (yamlFile, doc))
+    return loadConfig (id, file);
+}
+
+void ConfigController::unloadConfig (const juce::Identifier& id)
+{
+    checkForConfigAndThrowIfNotFound (id);
+
+    Logger::logInfo ("ConfigController: Unloading config with id: " + id.toString());
+
+    listeners.call (&Listener::configWillBeRemoved, *configs.at (id));
+    configs.erase (id);
+}
+
+void ConfigController::populateFromConfigDir()
+{
+    const auto configDir = Globals::getConfigDir();
+
+    if (! configDir.isDirectory())
     {
-        Logger::logError ("Failed to parse YAML file");
-        return std::nullopt;
+        Logger::logWarn ("ConfigController: Config directory does not exist: " + configDir.getFullPathName());
+        return;
     }
 
-    if (! validateYamlDocument (doc))
-    {
-        Logger::logError ("Failed to validate YAML file");
-        return std::nullopt;
-    }
+    Logger::logInfo ("ConfigController: Scanning config directory for YAML files: " + configDir.getFullPathName());
 
-    AppConfig cfg;
-    auto appRoot = doc.node["app"];
-    auto root = doc.node;
+    const auto yamlFiles = configDir.findChildFiles (juce::File::TypesOfFileToFind::findFiles, true, "*." + Globals::getConfigFileExtension());
+    auto result = true;
+
+    for (const auto& yamlFile : yamlFiles)
+        result &= loadConfig (yamlFile);
+
+    if (! result)
+        Logger::logWarn ("ConfigController: At least one config file could not be loaded successfully.");
+}
+
+bool ConfigController::loadConfig (const juce::Identifier& id, const juce::File& yamlFile)
+{
+    // id and file name have to match.
+    jassert (id.toString() == yamlFile.getFileNameWithoutExtension());
+
+    if (configs.contains (id))
+        unloadConfig (id);
 
     try
     {
-        // Required strings
-        cfg.id = juce::Identifier (yamlFile.getFileNameWithoutExtension());
-        cfg.name = root["name"].as<std::string>();
-        cfg.description = root["description"].as<std::string>();
+        auto [iter, success] = configs.try_emplace (id, std::make_unique<YamlConfig> (yamlFile));
 
-        cfg.workingDir = juce::File (appRoot["workingDir"].as<std::string>());
+        if (success)
+        {
+            listeners.call (&Listener::configAdded, *iter->second);
+            Logger::logInfo ("ConfigController: Loaded config with id: " + id.toString());
+        }
+        else
+        {
+            Logger::logError ("ConfigController: Error adding config with id: " + id.toString());
+        }
 
-        // Arrays
-        cfg.startCommand.clear();
-        for (const auto& child : appRoot["startCommand"])
-            cfg.startCommand.add (child.as<std::string>());
-
-        cfg.stopCommand.clear();
-        for (const auto& child : appRoot["stopCommand"])
-            cfg.stopCommand.add (child.as<std::string>());
-
-        // Booleans (optional, default true)
-        if (appRoot["captureStdOut"])
-            cfg.captureStdOut = (appRoot["captureStdOut"].as<bool>());
-        if (appRoot["captureStdErr"])
-            cfg.captureStdErr = (appRoot["captureStdErr"].as<bool>());
+        return success;
     }
-    catch (const std::exception& e)
+    catch (const std::runtime_error& e)
     {
-        Logger::logError (juce::String ("Error loading AppConfig: ") + e.what());
-        return std::nullopt;
+        Logger::logError ("ConfigController: Error loading config with id: " + id.toString() + " (" + e.what() + ").");
     }
 
-    Logger::logInfo ("Config file loaded successfully!");
-    return cfg;
+    return false;
 }
 
-bool ConfigController::parseYamlFile (const juce::File& yamlFile, YamlDocument& document)
+void ConfigController::checkForConfigAndThrowIfNotFound (const juce::Identifier& id) const
 {
-    if (! yamlFile.existsAsFile())
-    {
-        Logger::logError (juce::String ("ConfigController::parseYamlFile(): Config file not found."));
-        return false;
-    }
-
-    try
-    {
-        document.node = YAML::LoadFile (yamlFile.getFullPathName().toStdString());
-    }
-    catch (const std::exception& e)
-    {
-        Logger::logError (juce::String ("ConfigController::parseYamlFile(): Failed to parse YAML file with error: ") + e.what());
-        return false;
-    }
-
-    return true;
-}
-
-bool ConfigController::validateYamlDocument (const YamlDocument& document)
-{
-    // check top level contents
-    const auto root = document.node;
-
-    for (const char* key : { "name", "description" })
-    {
-        if (! root[key])
-        {
-            Logger::logError (juce::String ("Missing key '") + key + "'");
-            return false;
-        }
-    }
-
-    // check "app" if it exists
-    if (document.node["app"])
-    {
-        const auto appRoot = document.node["app"];
-
-        // Check required string entries
-        for (const char* key : { "workingDir" })
-        {
-            if (! appRoot[key])
-            {
-                Logger::logError (juce::String ("Missing key '") + key + "'");
-                return false;
-            }
-        }
-
-        // Check startCommand and stopCommand arrays
-        for (const char* key : { "startCommand", "stopCommand" })
-        {
-            if (! appRoot[key] || ! appRoot[key].IsSequence())
-            {
-                Logger::logError (juce::String ("Missing or invalid '") + key + "' (must be a sequence)");
-                return false;
-            }
-        }
-    }
-
-    return true;
+    if (! configs.contains (id))
+        throw ConfigNotFoundException (id);
 }
 
 } // namespace mrlab::controller

--- a/src/controller/ConfigController.h
+++ b/src/controller/ConfigController.h
@@ -1,5 +1,5 @@
 /*
-    AppConfigController.h
+    ConfigController.h
 
     Part of MR Lab Control Software
 
@@ -36,8 +36,8 @@ struct AppConfig
 };
 
 //==============================================================================
-/** Manage and provide app configurations from config files. */
-class AppConfigController
+/** Manage and provide app/scene/... configurations from config files. */
+class ConfigController
 {
 public:
     struct YamlDocument
@@ -47,11 +47,11 @@ public:
 
     //==============================================================================
     /** Exception that is thrown when there is no app for the given id. */
-    class AppConfigNotFoundException : public std::exception
+    class ConfigNotFoundException : public std::exception
     {
     public:
-        AppConfigNotFoundException (const juce::Identifier& appId)
-            : msg ("AppConfigNotFoundException: no app config found for id " + appId.toString())
+        ConfigNotFoundException (const juce::Identifier& appId)
+            : msg ("ConfigNotFoundException: no app config found for id " + appId.toString())
         {}
 
         const char* what() const noexcept override { return msg.toUTF8(); }
@@ -61,7 +61,7 @@ public:
     };
 
     //==============================================================================
-    AppConfigController();
+    ConfigController();
 
     // Temporary test config ids
     inline static const auto configFly = juce::Identifier ("pd-fly");
@@ -72,7 +72,7 @@ public:
     /** Get the app configuration for appId.
 
         @returns AppConfig for appId.
-        @throws AppConfigNotFoundException.
+        @throws ConfigNotFoundException.
      */
     AppConfig findConfig (const juce::Identifier& appId) const;
 
@@ -88,7 +88,7 @@ public:
 private:
     //==============================================================================
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AppConfigController)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ConfigController)
 };
 
 } // namespace mrlab::controller

--- a/src/controller/ConfigController.h
+++ b/src/controller/ConfigController.h
@@ -9,84 +9,132 @@
 
 #pragma once
 
+#include <map>
 #include <juce_core/juce_core.h>
-#include <yaml-cpp/yaml.h>
+#include <util/ListenerInterface.h>
 
 namespace mrlab::controller
 {
+class YamlConfig;
 
 //==============================================================================
-/** Preliminary incomplete app config record for testing.
-
-    To be outsourced to a separate file and extended by file reading capabilities.
- */
-struct AppConfig
-{
-    juce::Identifier id;      ///< Unique app identifier.
-    juce::String name;        ///< Short name to be displayed in user interfaces.
-    juce::String description; ///< Detailed app description.
-
-    juce::StringArray startCommand; ///< Command line to execute for launching (executable and arguments).
-    juce::StringArray stopCommand;  ///< Command line to execute for quitting (if empty, kill will be used).
-
-    juce::File workingDir; ///< Working directory for app launching.
-
-    bool captureStdOut = true; ///< Flag to indicate whether to capture the app's std output.
-    bool captureStdErr = true; ///< Flag to indicate whether to capture the app's std error.
-};
-
-//==============================================================================
-/** Manage and provide app/scene/... configurations from config files. */
+/** Manage and provide configurations from YAML config files. */
 class ConfigController
 {
 public:
-    struct YamlDocument
+    //==============================================================================
+    /** Exception that is thrown when there is no config for the given id. */
+    class ConfigNotFoundException : public std::runtime_error
     {
-        YAML::Node node;
+    public:
+        ConfigNotFoundException (const juce::Identifier& id)
+            : std::runtime_error ("ConfigNotFoundException: No config found for id " + id.toString().toStdString())
+        {}
     };
 
     //==============================================================================
-    /** Exception that is thrown when there is no app for the given id. */
-    class ConfigNotFoundException : public std::exception
+    /** Listener interface to get informed about currently managed configs. */
+    struct Listener
     {
-    public:
-        ConfigNotFoundException (const juce::Identifier& appId)
-            : msg ("ConfigNotFoundException: no app config found for id " + appId.toString())
-        {}
+        virtual ~Listener() = default;
 
-        const char* what() const noexcept override { return msg.toUTF8(); }
+        /** Called when a configuration was added (i.e., loaded).
 
-    protected:
-        juce::String msg;
+            @param id Id of the added config.
+         */
+        virtual void configAdded (const YamlConfig& config) = 0;
+
+        /** Called when a configuration is about to be removed.
+
+            This will also be called prior to reloading a configuration.
+
+            @param id Id of the config to be removed.
+         */
+        virtual void configWillBeRemoved (const YamlConfig& config) = 0;
     };
 
     //==============================================================================
     ConfigController();
+    ~ConfigController();
 
-    // Temporary test config ids
-    inline static const auto configFly = juce::Identifier ("pd-fly");
-    inline static const auto configReverb = juce::Identifier ("reaper-reverb");
-    inline static const auto configJungle = juce::Identifier ("pd-jungle");
-    inline static const auto configMusic = juce::Identifier ("reaper-music");
+    /** Get the configuration for id.
 
-    /** Get the app configuration for appId.
-
-        @returns AppConfig for appId.
+        @param id Id of the config to retrieve.
+        @returns Reference to the queried configuration.
         @throws ConfigNotFoundException.
      */
-    AppConfig findConfig (const juce::Identifier& appId) const;
+    const YamlConfig& getConfig (const juce::Identifier& id) const;
 
-    /** Loads and app config from a yaml file while also checking it for validity. */
-    static std::optional<AppConfig> loadConfigFromFile (const juce::File& yamlFile);
+    /** Load a config from a YAML file.
 
-    /** */
-    static bool parseYamlFile (const juce::File& yamlFile, YamlDocument& document);
+        The id of the YamlConfig is determined by its filename
+        (without path or extension).
 
-    /** Validates the contents of a yaml AppConfig description to be a valid one. */
-    static bool validateYamlDocument (const YamlDocument& yamlFile);
+        @note If a configuration with this id is already known/loaded,
+              it will be removed first, so this function can also be
+              used for reloading a config file.
+
+        @param yamlFile The config file to (re-) load.
+
+        @return true if the config could be successfully (re-) loaded,
+                false on error or exception (will be logged).
+     */
+    bool loadConfig (const juce::File& yamlFile);
+
+    /** Load a config file by specifying its id.
+
+        By definition, the id of a YamlConfig is determined by its
+        filename. Hence, this function will construct a filename from
+        the given id and attempt to load a configuration from it. If a
+        configuration with this id is already known/loaded, it will be
+        removed first, so this function can also be used for reloading
+        a config file.
+
+        @param id The config id to (re-) load.
+
+        @return true if the config could be successfully (re-) loaded,
+                false on error or exception (will be logged).
+     */
+    bool loadConfig (const juce::Identifier& id);
+
+    /** Remove the configuration for id.
+
+        @param id Id of the config to unload.
+        @throws ConfigNotFoundException.
+     */
+    void unloadConfig (const juce::Identifier& id);
+
+    /** Read all configurations from the globally set Config dir. */
+    void populateFromConfigDir();
+
+    /** @returns the number of managed configurations. */
+    size_t getNumConfigurations() { return configs.size(); }
+
+    /** @returns a const reference to the map of managed configurations. */
+    const std::map<juce::Identifier, std::unique_ptr<YamlConfig>>& getConfigurations() { return configs; }
 
 private:
     //==============================================================================
+    /** Load a config from file.
+
+        @param id The config id to assign.
+        @param yamlFile The config file to load.
+
+        @note The id param should match the yamlFile param (filename
+              without path and extension).
+
+        @return true if the config could be successfully (re-) loaded,
+                false on error or exception (will be logged).
+     */
+    bool loadConfig (const juce::Identifier& id, const juce::File& yamlFile);
+
+    /** Check whether we know about a config id and throw an exception otherwise. */
+    void checkForConfigAndThrowIfNotFound (const juce::Identifier& id) const;
+
+    //==============================================================================
+    std::map<juce::Identifier, std::unique_ptr<YamlConfig>> configs; ///< Managed configs.
+
+    MRLAB_IMPLEMENT_LISTENER_INTERFACE
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ConfigController)
 };

--- a/src/controller/MainController.cpp
+++ b/src/controller/MainController.cpp
@@ -11,7 +11,7 @@
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
 #include <iostream>
-#include <Config.h>
+#include <Globals.h>
 
 namespace mrlab::controller
 {
@@ -28,7 +28,7 @@ MainController::MainController()
     startWebServer();
 
     juce::Timer::callAfterDelay (1200, [&] {
-        appController.populateFromSceneConfigDir();
+        appController.populateFromConfigDir();
     });
 }
 
@@ -38,7 +38,7 @@ void MainController::initialise()
     Logger::setCurrentLogger (&logger);
 
     // check for/create application support directory
-    const auto appSupportDir = Config::getAppSupportDir();
+    const auto appSupportDir = Globals::getAppSupportDir();
 
     if (! appSupportDir.isDirectory())
     {

--- a/src/controller/MainController.cpp
+++ b/src/controller/MainController.cpp
@@ -12,12 +12,13 @@
 #include <juce_events/juce_events.h>
 #include <iostream>
 #include <Globals.h>
+#include "YamlConfig.h"
 
 namespace mrlab::controller
 {
 
 MainController::MainController()
-    : appController (configController),
+    : appController (*this),
       oscController (*this),
       webServerController (*this)
 {
@@ -26,10 +27,11 @@ MainController::MainController()
 
     // Start web server.
     startWebServer();
+}
 
-    juce::Timer::callAfterDelay (1200, [&] {
-        appController.populateFromConfigDir();
-    });
+MainController::~MainController()
+{
+    Logger::setCurrentLogger (nullptr);
 }
 
 void MainController::initialise()

--- a/src/controller/MainController.cpp
+++ b/src/controller/MainController.cpp
@@ -17,7 +17,7 @@ namespace mrlab::controller
 {
 
 MainController::MainController()
-    : appController (appConfigController),
+    : appController (configController),
       oscController (*this),
       webServerController (*this)
 {

--- a/src/controller/MainController.h
+++ b/src/controller/MainController.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include "AppConfigController.h"
 #include "AppController.h"
+#include "ConfigController.h"
 #include "OscController.h"
 #include "WebServerController.h"
 #include <util/Logger.h>
@@ -43,7 +43,7 @@ private:
     void startWebServer();
 
     //==============================================================================
-    AppConfigController appConfigController;
+    ConfigController configController;
     AppController appController;
     OscController oscController;
     WebServerController webServerController;

--- a/src/controller/MainController.h
+++ b/src/controller/MainController.h
@@ -24,6 +24,10 @@ class MainController
 public:
     //==============================================================================
     MainController();
+    ~MainController();
+
+    /** @returns a reference to the ConfigController. */
+    ConfigController& getConfigController() { return configController; }
 
     /** @returns a reference to the AppController. */
     AppController& getAppController() { return appController; }

--- a/src/controller/OscController.cpp
+++ b/src/controller/OscController.cpp
@@ -16,36 +16,43 @@
 namespace mrlab::controller
 {
 
-OscController::OscController (MainController& newMainController)
-    : mainController (newMainController)
+OscController::OscController (MainController& mainControllerIn)
+    : mainController (mainControllerIn)
 {
     addMainServer (Globals::getOscListeningPort());
-
-    // Temporary hardcoded app-specific relay server.
-    addSubPathServer (juce::Identifier ("pd_fly"), "/app/pd_fly/osc", 9336, "localhost", 10003);
-    addSubPathServer (juce::Identifier ("reaper_reverb"), "/app/reaper_reverb/osc", 9338, "localhost", 10005);
-    addSubPathServer (juce::Identifier ("pd_jungle"), "/app/pd_jungle/osc", 9340, "localhost", 10007);
-    addSubPathServer (juce::Identifier ("reaper_music"), "/app/reaper_music/osc", 9342, "localhost", 10009);
 }
 
 OscController::~OscController()
-{}
+{
+    removeServer (mainServerId);
+}
 
 bool OscController::addSubPathServer (const juce::Identifier& id, std::string subPath, int listenPort, const juce::String& destination, int destinationPort)
 {
-    jassert (servers.contains (mainServerId)); // Main server should be initialised first!
+    // Main server should be initialised first!
+    if (! servers.contains (mainServerId))
+    {
+        Logger::logError ("OscController::addSubPathServer: Main server is not initialised, cannot add subserver.");
+        return false;
+    }
+
+    if (! subPath.starts_with ('/') || subPath.ends_with ('/'))
+    {
+        Logger::logError ("OscController::addSubPathServer: Malformed OSC subpath '" + subPath + "' (must have a leading and no trailing '/').");
+        return false;
+    }
 
     if (! addToServers (id, listenPort))
+    {
+        Logger::logError ("OscController::addSubPathServer: Error adding subserver for id: " + id.toString());
         return false;
+    }
 
     auto& subServer = servers.at (id);
     auto& mainServer = servers.at (mainServerId);
 
-    jassert (subPath.starts_with ('/')); // OSC subpath needs a leading '/'!
-    jassert (! subPath.ends_with ('/')); // OSC subpath must not have a trailing '/'!
-
     // Pattern-matching handler for transparent app-specific communication.
-    mainServer->add_method (subPath + "/*", nullptr, [&subServer, subPathLength = subPath.length(), dest = destination.toStdString(), destinationPort] (std::string_view path, const lo::Message& message) {
+    auto subPathHandler = [&subServer, subPathLength = subPath.length(), dest = destination.toStdString(), destinationPort] (std::string_view path, const lo::Message& message) {
         auto addr = lo::Address (dest, destinationPort);
 
         // Forward to subserver with subPath stripped from the path.
@@ -60,13 +67,22 @@ bool OscController::addSubPathServer (const juce::Identifier& id, std::string su
         lo_send_message_from (addr, lo_server (*subServer), strippedPath.data(), message);
 
         return 1; // Continue searching for other handlers.
-    });
+    };
+
+    auto [iter, success] = mainServerMethods.try_emplace (id, mainServer->add_method (subPath + "/*", nullptr, std::move (subPathHandler)));
+
+    if (! success)
+    {
+        Logger::logError (juce::String ("OscController::addSubPathServer: Error adding message handler for OSC subpath ") + subPath + ", id: " + id.toString());
+        removeServer (id);
+        return false;
+    }
 
     // Catch-all handler for return messages from app.
-    subServer->add_method (nullptr, nullptr, [this, sub = std::move (subPath)] (std::string_view path, const lo::Message& message) {
+    subServer->add_method (nullptr, nullptr, [this, subPath] (std::string_view path, const lo::Message& message) {
         // Should be forwarded to main server with subPath added to app-local path.
         // For now, just send to WebSocket clients (webgui).
-        auto fullPath = sub + std::string (path);
+        auto fullPath = subPath + std::string (path);
         auto size = message.length (fullPath);
 
         std::vector<std::byte> serialised;
@@ -77,6 +93,8 @@ bool OscController::addSubPathServer (const juce::Identifier& id, std::string su
     });
 
     subServer->start();
+
+    Logger::logInfo (juce::String ("OscController::addSubPathServer: Added OSC subpath server for '") + subPath + "', listenPort: " + juce::String (listenPort) + ", destination: [" + destination + ", " + juce::String (destinationPort) + "].");
 
     return true;
 }
@@ -89,7 +107,19 @@ bool OscController::removeServer (const juce::Identifier& id)
         return false;
     }
 
-    // TODO implement
+    if (mainServerMethods.contains (id))
+    {
+        // Remove app-specific subpath message handler.
+        servers.at (mainServerId)->del_method (mainServerMethods.at (id));
+        mainServerMethods.erase (id);
+    }
+
+    servers.at (id)->stop();
+    servers.erase (id);
+
+    if (id != mainServerId)
+        Logger::logInfo ("OscController::removeServer: Removed OSC subpath server for id: " + id.toString());
+
     return true;
 }
 

--- a/src/controller/OscController.cpp
+++ b/src/controller/OscController.cpp
@@ -11,6 +11,7 @@
 #include "MainController.h"
 #include <lo/lo_cpp.h>
 #include <util/Logger.h>
+#include <Globals.h>
 
 namespace mrlab::controller
 {
@@ -18,7 +19,7 @@ namespace mrlab::controller
 OscController::OscController (MainController& newMainController)
     : mainController (newMainController)
 {
-    addMainServer (7081);
+    addMainServer (Globals::getOscListeningPort());
 
     // Temporary hardcoded app-specific relay server.
     addSubPathServer (AppConfigController::configFly, "/app/pd_fly/osc", 9336, "localhost", 10003);

--- a/src/controller/OscController.cpp
+++ b/src/controller/OscController.cpp
@@ -22,10 +22,10 @@ OscController::OscController (MainController& newMainController)
     addMainServer (Globals::getOscListeningPort());
 
     // Temporary hardcoded app-specific relay server.
-    addSubPathServer (AppConfigController::configFly, "/app/pd_fly/osc", 9336, "localhost", 10003);
-    addSubPathServer (AppConfigController::configReverb, "/app/reaper_reverb/osc", 9338, "localhost", 10005);
-    addSubPathServer (AppConfigController::configJungle, "/app/pd_jungle/osc", 9340, "localhost", 10007);
-    addSubPathServer (AppConfigController::configMusic, "/app/reaper_music/osc", 9342, "localhost", 10009);
+    addSubPathServer (ConfigController::configFly, "/app/pd_fly/osc", 9336, "localhost", 10003);
+    addSubPathServer (ConfigController::configReverb, "/app/reaper_reverb/osc", 9338, "localhost", 10005);
+    addSubPathServer (ConfigController::configJungle, "/app/pd_jungle/osc", 9340, "localhost", 10007);
+    addSubPathServer (ConfigController::configMusic, "/app/reaper_music/osc", 9342, "localhost", 10009);
 }
 
 OscController::~OscController()

--- a/src/controller/OscController.cpp
+++ b/src/controller/OscController.cpp
@@ -22,10 +22,10 @@ OscController::OscController (MainController& newMainController)
     addMainServer (Globals::getOscListeningPort());
 
     // Temporary hardcoded app-specific relay server.
-    addSubPathServer (ConfigController::configFly, "/app/pd_fly/osc", 9336, "localhost", 10003);
-    addSubPathServer (ConfigController::configReverb, "/app/reaper_reverb/osc", 9338, "localhost", 10005);
-    addSubPathServer (ConfigController::configJungle, "/app/pd_jungle/osc", 9340, "localhost", 10007);
-    addSubPathServer (ConfigController::configMusic, "/app/reaper_music/osc", 9342, "localhost", 10009);
+    addSubPathServer (juce::Identifier ("pd_fly"), "/app/pd_fly/osc", 9336, "localhost", 10003);
+    addSubPathServer (juce::Identifier ("reaper_reverb"), "/app/reaper_reverb/osc", 9338, "localhost", 10005);
+    addSubPathServer (juce::Identifier ("pd_jungle"), "/app/pd_jungle/osc", 9340, "localhost", 10007);
+    addSubPathServer (juce::Identifier ("reaper_music"), "/app/reaper_music/osc", 9342, "localhost", 10009);
 }
 
 OscController::~OscController()

--- a/src/controller/OscController.h
+++ b/src/controller/OscController.h
@@ -19,6 +19,7 @@ namespace lo
 {
 class ServerThread;
 class Message;
+class Method;
 }
 
 namespace mrlab::controller
@@ -49,7 +50,7 @@ public:
     /**
 
      */
-    OscController (MainController& newMainController);
+    OscController (MainController& mainControllerIn);
 
     /**
 
@@ -96,6 +97,7 @@ private:
     //==============================================================================
     MainController& mainController;
     std::map<juce::Identifier, std::unique_ptr<lo::ServerThread>> servers; ///< Managed server instances.
+    std::map<juce::Identifier, lo::Method> mainServerMethods; ///< OSC methods added to main server per id.
 
     MRLAB_IMPLEMENT_LISTENER_INTERFACE
 

--- a/src/controller/WebServerController.cpp
+++ b/src/controller/WebServerController.cpp
@@ -8,7 +8,6 @@
  */
 
 #include "WebServerController.h"
-#include "AppConfigController.h"
 #include "MainController.h"
 #include "OscController.h"
 #include <iostream>

--- a/src/controller/WebServerController.cpp
+++ b/src/controller/WebServerController.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <lo/lo_cpp.h>
 #include <util/Logger.h>
-#include <Config.h>
+#include <Globals.h>
 
 namespace mrlab::controller
 {
@@ -43,7 +43,7 @@ bool WebServerController::start()
         return false;
     }
 
-    const auto documentRootDir = Config::getWebServerDocumentRootDir();
+    const auto documentRootDir = Globals::getWebServerDocumentRootDir();
     const auto documentRoot = documentRootDir.getFullPathName();
 
     if (documentRootDir.isDirectory())
@@ -56,7 +56,7 @@ bool WebServerController::start()
     civetOptions.push_back ("document_root");
     civetOptions.push_back (documentRoot.toStdString());
     civetOptions.push_back ("listening_ports");
-    civetOptions.push_back (std::to_string (Config::getWebServerListeningPort()));
+    civetOptions.push_back (std::to_string (Globals::getWebServerListeningPort()));
     civetOptions.push_back ("websocket_timeout_ms");
     civetOptions.push_back (std::to_string (5000));
     civetOptions.push_back ("enable_websocket_ping_pong");

--- a/src/controller/WebServerController.cpp
+++ b/src/controller/WebServerController.cpp
@@ -162,7 +162,7 @@ void WebServerController::appStateChanged (AppHandle& app, AppHandle::AppState n
     message.add (int (newState));
     message.add_string (AppHandle::appStateNames.at (newState).toStdString());
 
-    auto oscPath = std::string ("/app/") + app.getConfig().id.toString().toStdString() + "/state";
+    auto oscPath = std::string ("/app/") + app.getId().toString().toStdString() + "/state";
     auto size = message.length (oscPath);
 
     std::vector<std::byte> serialised;

--- a/src/controller/YamlConfig.cpp
+++ b/src/controller/YamlConfig.cpp
@@ -1,0 +1,139 @@
+/*
+    YamlConfig.cpp
+
+    Part of MR Lab Control Software
+
+    SPDX-License-Identifier: EUPL-1.2
+    SPDX-FileCopyrightText: Copyright (c) 2026 Martin Rumori/sonible GmbH
+ */
+
+#include "YamlConfig.h"
+
+namespace mrlab::controller
+{
+
+YamlConfig::YamlConfig (const juce::File& yamlFile)
+    : id (yamlFile.getFileNameWithoutExtension())
+{
+    load (yamlFile);
+    validate();
+}
+
+void YamlConfig::load (const juce::File& yamlFile)
+{
+    node = YAML::LoadFile (yamlFile.getFullPathName().toStdString());
+}
+
+void YamlConfig::validate()
+{
+    // Check top level keys.
+    // mandatory: name
+    validateMandatoryWithType<std::string> (node["name"], "name", "string");
+
+    // optional: description, author, date
+    for (const char* key : { "description", "author", "date" })
+        validateOptionalWithDefault (node[key], std::string(), key, "string");
+
+    // optional: revision
+    validateOptionalWithDefault (node["revision"], 0, "revision", "int");
+
+    // Validate "app" section if it exists.
+    if (hasSection (Section::app))
+    {
+        auto appRoot = getSection (Section::app);
+
+        // optional: workingDir
+        validateOptionalWithDefault (appRoot["workingDir"], std::string(), "app:workingDir", "string");
+
+        // mandatory: startCommand and stopCommand arrays
+        for (const char* key : { "startCommand", "stopCommand" })
+        {
+            const auto& n = appRoot[key];
+
+            if (! (n && n.IsSequence()))
+                throw InvalidConfigException (std::string ("Missing or invalid key 'app:") + key + "', must be a sequence of <string>");
+
+            for (const auto& nn : n)
+            {
+                try
+                {
+                    nn.as<std::string>();
+                }
+                catch (const YAML::BadConversion& e)
+                {
+                    throw InvalidConfigException (std::string ("Invalid key 'app:") + key + "', all sequence members must be of type <string> [" + e.what() + "]");
+                }
+            }
+        }
+
+        // optional: output capture flags
+        for (const char* key : { "captureStdOut", "captureStdErr" })
+            validateOptionalWithDefault (appRoot[key], false, std::string ("app:") + key, "bool");
+
+        // Validate "oscClients" subsection.
+        const auto& oscClients = appRoot["oscClients"];
+
+        if (oscClients)
+        {
+            if (! oscClients.IsSequence())
+                throw InvalidConfigException (std::string ("Invalid key 'app:oscClients', must be a sequence of mappings"));
+
+            // Check oscClients sequence members.
+            for (auto i = 0; auto osc : oscClients)
+            {
+                std::string msgKey = std::string ("app:oscClients[") + std::to_string (i++) + "]";
+
+                if (! osc.IsMap())
+                    throw InvalidConfigException (std::string ("Invalid key '" + msgKey + "', all sequence members must be of type <mapping>"));
+
+                // mandatory id, subPath, listenPort
+                validateMandatoryWithType<std::string> (osc["id"], msgKey + ":id", "string");
+                validateMandatoryWithType<std::string> (osc["subPath"], msgKey + ":subPath", "string");
+                validateMandatoryWithType<uint16_t> (osc["listenPort"], msgKey + ":listenPort", "int");
+
+                // optional prefix
+                validateOptionalWithDefault (osc["prefix"], std::string(), msgKey + ":prefix", "string");
+
+                // Validate "destination".
+                auto destination = osc["destination"];
+
+                if (! (destination && destination.IsSequence() && destination.size() == 2))
+                    throw InvalidConfigException (std::string ("Missing or invalid key '" + msgKey + ":destination', must be a sequence of <string, int>"));
+
+                validateMandatoryWithType<std::string> (destination[0], msgKey + ":destination[0]", "string");
+                validateMandatoryWithType<uint16_t> (destination[1], msgKey + ":destination[1]", "int");
+            }
+        }
+    }
+}
+
+template <std::common_reference_with<YAML::Node> NodeType, typename T>
+void YamlConfig::validateOptionalWithDefault (NodeType&& n, T defaultValue, std::string msgKey, std::string msgType)
+{
+    if (n)
+        return validateMandatoryWithType<T> (n, std::move (msgKey), std::move (msgType));
+
+    n = defaultValue;
+    return;
+}
+
+template <typename T>
+void YamlConfig::validateMandatoryWithType (const YAML::Node& n, std::string msgKey, std::string msgType)
+{
+    if (! n)
+        throw InvalidConfigException (std::string ("Missing key '") + msgKey + "' <" + msgType + ">");
+
+    if (! n.IsScalar())
+        throw InvalidConfigException (std::string ("Invalid key '") + msgKey + "', must be a scalar <" + msgType + ">");
+
+    try
+    {
+        n.as<T>();
+    }
+    catch (const YAML::BadConversion& e)
+    {
+        throw InvalidConfigException (std::string ("Invalid key '") + msgKey + "', must be of type <" + msgType + "> [" + e.what() + "]");
+    }
+}
+
+} // namespace mrlab::controller

--- a/src/controller/YamlConfig.h
+++ b/src/controller/YamlConfig.h
@@ -1,0 +1,176 @@
+/*
+    YamlConfig.h
+
+    Part of MR Lab Control Software
+
+    SPDX-License-Identifier: EUPL-1.2
+    SPDX-FileCopyrightText: Copyright (c) 2026 Martin Rumori/sonible GmbH
+ */
+
+#pragma once
+
+#include <juce_core/juce_core.h>
+#include <yaml-cpp/yaml.h>
+
+namespace mrlab::controller
+{
+
+//==============================================================================
+/** Configuration loaded from a file and represented as a YAML tree.
+
+    A configuration file may contain several sections, e.g., for app or
+    routing configurations.
+ */
+class YamlConfig
+{
+public:
+    //==============================================================================
+    /** Configuration section identifiers.
+
+        Allow for testing for and retrieving top-level sections (i.e.,
+        top-level map keys) of configuration files.
+     */
+    enum class Section
+    {
+        app = 0,                ///< Application section.
+        macros                  ///< Control macros section.
+    };
+
+    /** Section keys.
+
+        @note On Windows, yaml-cpp apparently does not swallow
+              std::map<Section, std::string_view>, hence const char*.
+     */
+    inline static const auto sectionKeys = std::map<Section, const char*> (
+        { { Section::app, "app" },
+          { Section::macros, "macros" } }
+    );
+
+    //==============================================================================
+    /** Exception that is thrown when the validation of the YAML config failed. */
+    class InvalidConfigException : public std::runtime_error
+    {
+    public:
+        InvalidConfigException (const std::string& what)
+            : std::runtime_error ("InvalidConfigException: " + what)
+        {}
+    };
+
+    /** Exception that is thrown when a config cannot be used in a certain context.
+
+        This may indicate that a config section is missing but required.
+     */
+    class UnusableConfigException : public std::runtime_error
+    {
+    public:
+        UnusableConfigException (const std::string& what)
+            : std::runtime_error ("UnusableConfigException: " + what)
+        {}
+    };
+
+    //==============================================================================
+    /** Create a YamlConfig by reading from a YAML configuration file.
+
+        This will attempt to parse the file into a YAML node and
+        validate it against internally stored requirements. If any of
+        these steps fails, an exception is thrown and no object is
+        constructed, such that any successfully constructed object can
+        be assumed to contain a valid configuration.
+
+        @param yamlFile File to load the configuration from.
+
+        @throws InvalidConfigException on a validation error and any
+                of the exceptions thrown by YAML::LoadFile and yaml-cpp
+                conversion operations.
+     */
+    YamlConfig (const juce::File& yamlFile);
+
+    /** Get the id of the configuration.
+
+        By definition, the configuration id is determined by its
+        filename (without any path or extension elements).
+
+        @returns The configuration id.
+     */
+    const juce::Identifier& getId() const { return id; }
+
+    /** @return a reference to the top-level YAML node of the configuration. */
+    const YAML::Node& get() const { return node; }
+
+    /** Convenience operator to directly access subnodes of the top-level YAML node. */
+    template <typename Key>
+    const YAML::Node operator[] (const Key& key) const { return node[key]; }
+
+    /** Retrieve the YAML node of a top-level configuration section.
+
+        @param section The configuration section to retrieve.
+        @return The corresponding YAML node (may be undefined in case it is not present).
+     */
+    const YAML::Node getSection (Section section) const { return node[sectionKeys.at (section)]; }
+
+    /** Check whether the configuration defines the specified top-level section. */
+    bool hasSection (Section section) const { return getSection (section).IsDefined(); }
+
+private:
+    //==============================================================================
+    /** Loads a config from a yaml file while also checking it for validity. */
+    void load (const juce::File& yamlFile);
+
+    /** Validates the config. */
+    void validate();
+
+    /** Validates an optional node and assigns a default value if none is set.
+
+        If the node is not defined, the provided default value will be
+        assigned. If the node is defined, it will be validated using
+        the type infered from the default value.
+
+        @tparam NodeType Type of the YAML node passed in (e.g., lvalue/rvalue/reference).
+        @tparam T Type to check whether the node can be converted to.
+        @param n Node to check.
+        @param msgKey Key identifier to be used in exception message.
+        @param msgType Type identifier to be used in exception message.
+        @throws InvalidConfigException
+
+        @note This expects the very YAML node to be validated as
+              parameter n. The msgKey parameter is not used for
+              accessing the node (i.e., from the parent node) but
+              merely for user information, as it also might indicate a
+              key hierarchy (e.g.,
+              "app:oscClients[0]:listenPort"). Similarly, the msgType
+              parameter is for user information only, as YAML type
+              requirements are most probably not communicated by the
+              C++ type names that are used in the respective
+              controller-specific implementations.
+     */
+    template <std::common_reference_with<YAML::Node> NodeType, typename T>
+    static void validateOptionalWithDefault (NodeType&& n, T defaultValue, std::string msgKey, std::string msgType);
+
+    /** Validates a node to be a scalar and convertible to a certain type.
+
+        @tparam T Type to check whether the node can be converted to.
+        @param n Node to check.
+        @param msgKey Key identifier to be used in exception message.
+        @param msgType Type identifier to be used in exception message.
+        @throws InvalidConfigException
+
+        @note This expects the very YAML node to be validated as
+              parameter n. The msgKey parameter is not used for
+              accessing the node (i.e., from the parent node) but
+              merely for user information, as it also might indicate a
+              key hierarchy (e.g.,
+              "app:oscClients[0]:listenPort"). Similarly, the msgType
+              parameter is for user information only, as YAML type
+              requirements are most probably not communicated by the
+              C++ type names that are used in the respective
+              controller-specific implementations.
+     */
+    template <typename T>
+    static void validateMandatoryWithType (const YAML::Node& n, std::string msgKey, std::string msgType);
+
+    //==============================================================================
+    juce::Identifier id;        ///< Config id.
+    YAML::Node node;            ///< Top-level YAML node.
+};
+
+} // namespace mrlab::controller

--- a/src/util/Logger.h
+++ b/src/util/Logger.h
@@ -45,7 +45,7 @@ public:
     };
 
     //==============================================================================
-    Logger() : juce::FileLogger (Globals::getAppSupportDir().getChildFile ("MRLabLog.txt"), "\n\n==== MRLabLog Session Start ====", maxFileSizeBytes) {}
+    Logger() : juce::FileLogger (Globals::getLogFile(), "\n\n==== MRLabLog Session Start ====", maxFileSizeBytes) {}
 
     //==============================================================================
     /** Convenience wrapper to write an info log message. */

--- a/src/util/Logger.h
+++ b/src/util/Logger.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <juce_core/juce_core.h>
-#include <Config.h>
+#include <Globals.h>
 #include <util/ListenerInterface.h>
 
 namespace mrlab
@@ -45,7 +45,7 @@ public:
     };
 
     //==============================================================================
-    Logger() : juce::FileLogger (Config::getAppSupportDir().getChildFile ("MRLabLog.txt"), "\n\n==== MRLabLog Session Start ====", maxFileSizeBytes) {}
+    Logger() : juce::FileLogger (Globals::getAppSupportDir().getChildFile ("MRLabLog.txt"), "\n\n==== MRLabLog Session Start ====", maxFileSizeBytes) {}
 
     //==============================================================================
     /** Convenience wrapper to write an info log message. */

--- a/src/view/AppControlComponent.cpp
+++ b/src/view/AppControlComponent.cpp
@@ -15,7 +15,7 @@ namespace mrlab::view
 
 AppControlComponent::AppControlComponent (controller::AppHandle& appHandle)
     : app (appHandle),
-      appIdLabel ("AppControlComponent::appIdLabel", app.getConfig().id.toString()),
+      appIdLabel ("AppControlComponent::appIdLabel", app.getId().toString()),
       statusLabel ("AppControlComponent::statusLabel"),
       launchQuitButton ("AppControlComponent::launchQuitButton"),
       killButton ("AppControlComponent::killButton"),

--- a/src/view/AppControlComponent.h
+++ b/src/view/AppControlComponent.h
@@ -32,7 +32,7 @@ public:
     void resized() override;
 
     /** @returns the id of the app represented by this. */
-    juce::Identifier getId() const { return app.getConfig().id; }
+    juce::Identifier getId() const { return app.getId(); }
 
 private:
     //==============================================================================

--- a/src/view/MainComponent.cpp
+++ b/src/view/MainComponent.cpp
@@ -51,7 +51,7 @@ void MainComponent::appAdded (controller::AppHandle& app)
 
 void MainComponent::appWillBeRemoved (controller::AppHandle& app)
 {
-    const auto it = std::find_if (appControls.begin(), appControls.end(), [id = app.getConfig().id] (auto& c) { return c->getId() == id; });
+    const auto it = std::find_if (appControls.begin(), appControls.end(), [id = app.getId()] (auto& c) { return c->getId() == id; });
 
     if (it == appControls.end())
         return;

--- a/src/view/MainComponent.cpp
+++ b/src/view/MainComponent.cpp
@@ -11,7 +11,6 @@
 #include "AppControlComponent.h"
 #include <controller/MainController.h>
 #include <controller/AppHandle.h>
-#include <controller/AppConfigController.h>
 
 
 namespace mrlab::view

--- a/test/AppControllerTest.cpp
+++ b/test/AppControllerTest.cpp
@@ -9,36 +9,31 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <controller/AppController.h>
-#include <controller/AppConfigController.h>
+#include <controller/MainController.h>
 #include <controller/AppHandle.h>
 
 namespace mrlab
 {
 
-TEST_CASE ("App configurations and handles", "[AppControllerTest]")
+TEST_CASE ("App handle controller", "[AppControllerTest]")
 {
-    controller::AppConfigController appConfigController;
+    controller::MainController mainController;
+    controller::ConfigController& configController = mainController.getConfigController();
+    controller::AppController& appController = mainController.getAppController();
 
-    SECTION ("Access hardcoded example configurations")
+    SECTION ("Load and acess example configurations")
     {
-        REQUIRE_NOTHROW (appConfigController.findConfig (controller::AppConfigController::configFly));
-        REQUIRE_NOTHROW (appConfigController.findConfig (controller::AppConfigController::configReverb));
-        REQUIRE_THROWS (appConfigController.findConfig (juce::Identifier ("non-existent")));
-    }
+        juce::Identifier reaperTest = "reaper_test_mac";
+        juce::Identifier pdTest = "pd_test_mac";
 
-    controller::AppController appController (appConfigController);
-
-    SECTION ("Add and access example configurations")
-    {
-        appController.add (controller::AppConfigController::configFly);
-        appController.add (controller::AppConfigController::configReverb);
+        REQUIRE (configController.loadConfig (reaperTest));
+        REQUIRE (configController.loadConfig (pdTest));
 
         REQUIRE (appController.getApps().size() == 2);
 
-        auto& app = appController.getApp (controller::AppConfigController::configFly);
+        const auto& app = appController.getApp (reaperTest);
 
-        REQUIRE (app.getConfig().id == controller::AppConfigController::configFly);
+        REQUIRE (app.getId() == reaperTest);
         REQUIRE (app.getState() == controller::AppHandle::AppState::initial);
     }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 # SPDX-FileCopyrightText: Copyright (c) 2025 Martin Rumori/sonible GmbH
 
-CPMAddPackage ("gh:catchorg/Catch2@3.11.0")
+CPMAddPackage ("gh:catchorg/Catch2@3.12.0")
 
 #====================================================================================
 juce_add_console_app (mrlabctrl_UnitTest
@@ -14,16 +14,16 @@ juce_add_console_app (mrlabctrl_UnitTest
     BUNDLE_ID     com.sonible.mrlabctrl_unittest
 )
 
-# We do not intend to use JuceHeader.h generally,
-# this is just for exploiting its ProjectInfo:: facility.
-juce_generate_juce_header (mrlabctrl_UnitTest)
-
 add_dependencies (run_tests mrlabctrl_UnitTest)
 
 set_target_properties (mrlabctrl_UnitTest
     PROPERTIES
         EXCLUDE_FROM_ALL TRUE
 )
+
+configure_file (TestGlobals.cpp.in TestGlobals.cpp ESCAPE_QUOTES)
+
+target_include_directories (mrlabctrl_UnitTest PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 
 target_link_libraries (mrlabctrl_UnitTest
     PRIVATE
@@ -33,6 +33,8 @@ target_link_libraries (mrlabctrl_UnitTest
 
 target_sources (mrlabctrl_UnitTest
     PRIVATE
+        TestGlobals.cpp
+        ConfigControllerTest.cpp
         AppControllerTest.cpp
 )
 

--- a/test/ConfigControllerTest.cpp
+++ b/test/ConfigControllerTest.cpp
@@ -1,0 +1,84 @@
+/*
+    ConfigControllerTest.cpp
+
+    Part of MR Lab Control Software
+
+    SPDX-License-Identifier: EUPL-1.2
+    SPDX-FileCopyrightText: Copyright (c) 2026 Martin Rumori/sonible GmbH
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <controller/ConfigController.h>
+#include <controller/YamlConfig.h>
+#include <Globals.h>
+#include <util/Logger.h>
+
+namespace mrlab
+{
+
+TEST_CASE ("YAML configuration file controller", "[ConfigControllerTest]")
+{
+    controller::ConfigController configController;
+
+    SECTION ("Load and access example configurations")
+    {
+        REQUIRE (configController.loadConfig (Globals::getConfigDir().getChildFile ("reaper_test_mac.yaml")));
+        REQUIRE (configController.loadConfig (Globals::getConfigDir().getChildFile ("pd_test_mac.yaml")));
+
+        REQUIRE (configController.getConfigurations().size() == 2);
+
+        REQUIRE_NOTHROW (configController.getConfig (juce::Identifier ("reaper_test_mac")));
+        REQUIRE_NOTHROW (configController.getConfig (juce::Identifier ("pd_test_mac")));
+
+        REQUIRE_THROWS_AS (configController.getConfig (juce::Identifier ("non_existent")), controller::ConfigController::ConfigNotFoundException);
+    }
+
+
+    SECTION ("Listener interface when loading and reloading a configuration")
+    {
+        struct listener : public controller::ConfigController::Listener
+        {
+            void configAdded (const controller::YamlConfig&) override { ++addedCount; }
+            void configWillBeRemoved (const controller::YamlConfig&) override { ++removedCount; }
+
+            int addedCount = 0;
+            int removedCount = 0;
+        } listener;
+
+        configController.addListener (&listener);
+
+        CHECK (listener.addedCount == 0); REQUIRE (listener.removedCount == 0);
+
+        // load
+        CHECK (configController.loadConfig (Globals::getConfigDir().getChildFile ("reaper_test_mac.yaml")));
+        CHECK (listener.addedCount == 1); REQUIRE (listener.removedCount == 0);
+
+        // reload
+        CHECK (configController.loadConfig ("reaper_test_mac"));
+        CHECK (listener.addedCount == 2); REQUIRE (listener.removedCount == 1);
+
+        // unload
+        CHECK_NOTHROW (configController.unloadConfig ("reaper_test_mac"));
+        CHECK (listener.addedCount == 2); REQUIRE (listener.removedCount == 2);
+
+        configController.removeListener (&listener);
+    }
+
+
+    SECTION ("Load and validate all YAML configuration files from resources")
+    {
+        // Set up logger facility.
+        Logger logger;
+        Logger::setCurrentLogger (&logger);
+
+        // Should log failures to test log file.
+        configController.populateFromConfigDir();
+
+        const auto numYamlFiles = Globals::getConfigDir().findChildFiles (juce::File::TypesOfFileToFind::findFiles, true, "*." + Globals::getConfigFileExtension()).size();
+
+        REQUIRE (configController.getNumConfigurations() == size_t (numYamlFiles));
+    }
+}
+
+} // namespace mrlab

--- a/test/TestGlobals.cpp.in
+++ b/test/TestGlobals.cpp.in
@@ -1,0 +1,44 @@
+/*
+    TestGlobals.cpp
+
+    Part of MR Lab Control Software
+
+    SPDX-License-Identifier: EUPL-1.2
+    SPDX-FileCopyrightText: Copyright (c) 2026 Martin Rumori/sonible GmbH
+ */
+
+#include "Globals.h"
+
+/* Globals.cpp implementation for test cases.
+
+   This points the app support directory to the source repository's
+   resources directory such that locally run test cases can refer to
+   the project resources.
+ */
+
+namespace mrlab
+{
+
+juce::File Globals::getAppSupportBaseDir()
+{
+    auto resourceDir = juce::File ("@CMAKE_SOURCE_DIR@").getChildFile ("resources");
+
+    /* Resource directory not present?
+       Test builds require the source tree from which they were built.
+     */
+    jassert (resourceDir.isDirectory());
+
+    return resourceDir;
+}
+
+juce::File Globals::getAppSupportDir()
+{
+    return getAppSupportBaseDir();
+}
+
+juce::File Globals::getLogFile()
+{
+    return juce::File ("@CMAKE_CURRENT_BINARY_DIR@").getChildFile ("MRLabLog_UnitTest.txt");
+}
+
+} // namespace mrlab


### PR DESCRIPTION
This allows for dynamically configuring an osc client channel (only one for the time being, multiple to come) with parameters like listening port and destination in (scene) configuration files.